### PR TITLE
feat: allow reconfiguring interface and prune orphaned registry entries

### DIFF
--- a/custom_components/homeassistant_grenton/__init__.py
+++ b/custom_components/homeassistant_grenton/__init__.py
@@ -3,6 +3,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .integration_config import GrentonConfigEntry, GrentonConfigEntryData, RuntimeData
 from .coordinator import GrentonCoordinator
@@ -47,12 +48,49 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: GrentonConfigEntr
     # Store runtime data
     config_entry.runtime_data = RuntimeData(coordinator=coordinator, devices=devices)
 
+    # Drop entities and devices that no longer exist in the freshly fetched interface
+    _cleanup_orphans(hass, config_entry, devices)
+
     # Setup the coordinator
     await coordinator.async_setup()
-    
+
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
+
+
+def _cleanup_orphans(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    devices: list,
+) -> None:
+    """Remove entity/device registry entries that no longer back a live widget.
+
+    Why: device_info identifiers and entity unique_ids are derived from widget IDs
+    in the mobile interface JSON. After a reconfigure that drops widgets, the old
+    registry rows would otherwise linger as `unavailable`.
+    """
+    valid_entity_uids: set[str] = {
+        entity.unique_id
+        for device in devices
+        for entity in device.entities
+        if entity.unique_id
+    }
+    valid_device_identifiers: set[tuple[str, str]] = {
+        ("grenton", device.id) for device in devices
+    }
+
+    entity_reg = er.async_get(hass)
+    for entry in er.async_entries_for_config_entry(entity_reg, config_entry.entry_id):
+        if entry.unique_id not in valid_entity_uids:
+            _LOGGER.debug("Removing orphaned entity %s (uid=%s)", entry.entity_id, entry.unique_id)
+            entity_reg.async_remove(entry.entity_id)
+
+    device_reg = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(device_reg, config_entry.entry_id):
+        if not any(identifier in valid_device_identifiers for identifier in device.identifiers):
+            _LOGGER.debug("Removing orphaned device %s", device.id)
+            device_reg.async_update_device(device.id, remove_config_entry_id=config_entry.entry_id)
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     coordinator: GrentonCoordinator = config_entry.runtime_data.coordinator

--- a/custom_components/homeassistant_grenton/config_flow.py
+++ b/custom_components/homeassistant_grenton/config_flow.py
@@ -68,10 +68,10 @@ class GrentonConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 interface_id = str(data.get("id"))
-                
+
                 await self.async_set_unique_id(interface_id)
                 self._abort_if_unique_id_configured()
-            
+
                 return self.async_create_entry(
                     title=interface_id,
                     data={
@@ -79,10 +79,50 @@ class GrentonConfigFlow(ConfigFlow, domain=DOMAIN):
                         "interface": data
                     }
                 )
-            
+
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Re-fetch the mobile interface for the existing config entry."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input:
+            try:
+                data = await self._validate_and_fetch(user_input)
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except InvalidData:
+                errors["base"] = "invalid_data"
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception as e:
+                _LOGGER.exception("Unexpected exception: %s", e)
+                errors["base"] = "unknown"
+            else:
+                interface_id = str(data.get("id"))
+
+                await self.async_set_unique_id(interface_id)
+                self._abort_if_unique_id_mismatch(reason="wrong_interface")
+
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={**user_input, "interface": data},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA,
+                {
+                    CONF_IP_ADDRESS: entry.data.get(CONF_IP_ADDRESS),
+                    CONF_PORT: entry.data.get(CONF_PORT),
+                },
+            ),
             errors=errors,
         )
 

--- a/custom_components/homeassistant_grenton/translations/en.json
+++ b/custom_components/homeassistant_grenton/translations/en.json
@@ -11,6 +11,15 @@
           "port": "Port",
           "pin": "PIN"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Grenton Interface",
+        "description": "Re-enter the address, port and current PIN to fetch an updated interface. New widgets will be added; existing entities keep their configuration.",
+        "data": {
+          "ip_address": "IP Address",
+          "port": "Port",
+          "pin": "PIN"
+        }
       }
     },
     "error": {
@@ -18,6 +27,10 @@
       "invalid_data": "Data from the device was missing or malformed.",
       "cannot_connect": "Unable to connect to the Grenton Object Manager at the given address.",
       "unknown": "Unknown error occurred."
+    },
+    "abort": {
+      "reconfigure_successful": "Interface refreshed successfully.",
+      "wrong_interface": "The fetched interface belongs to a different installation than the one being reconfigured."
     }
   },
 

--- a/custom_components/homeassistant_grenton/translations/pl.json
+++ b/custom_components/homeassistant_grenton/translations/pl.json
@@ -11,6 +11,15 @@
           "port": "Port",
           "pin": "PIN"
         }
+      },
+      "reconfigure": {
+        "title": "Rekonfiguruj interfejs Grenton",
+        "description": "Podaj adres, port i aktualny PIN, aby pobrać zaktualizowany interfejs. Nowe widgety zostaną dodane, a istniejące encje zachowają swoją konfigurację.",
+        "data": {
+          "ip_address": "Adres IP",
+          "port": "Port",
+          "pin": "PIN"
+        }
       }
     },
     "error": {
@@ -18,6 +27,10 @@
       "invalid_data": "Dane z urządzenia były niekompletne lub nieprawidłowe.",
       "cannot_connect": "Nie można połączyć się z Grenton Object Manager pod podanym adresem.",
       "unknown": "Wystąpił nieznany błąd."
+    },
+    "abort": {
+      "reconfigure_successful": "Interfejs został pomyślnie odświeżony.",
+      "wrong_interface": "Pobrany interfejs należy do innej instalacji niż ta, która jest rekonfigurowana."
     }
   },
 


### PR DESCRIPTION
Add an async_step_reconfigure flow so a user can re-fetch the mobile interface (the PIN rotates each time, so refresh-only is not viable). A unique_id mismatch on the fetched interface aborts with wrong_interface to prevent overwriting one installation with another.

After every setup, drop entity_registry and device_registry rows whose unique_ids/identifiers no longer back a widget in the freshly mapped device list. Existing entities keep their unique_id (derived from the widget id), so their per-entity options persist across reconfigures.