### PR TITLE
feat: add SCENE widget with grenton.run_scene service

### DIFF
--- a/custom_components/homeassistant_grenton/button.py
+++ b/custom_components/homeassistant_grenton/button.py
@@ -1,12 +1,20 @@
 import logging
 
+import voluptuous as vol
+
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.button import ButtonEntity
 
 from . import GrentonConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_RUN_SCENE = "run_scene"
+SERVICE_RUN_SCENE_SCHEMA = {
+    vol.Optional("parameter"): cv.string,
+}
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -23,3 +31,13 @@ async def async_setup_entry(
                 entities.append(entity)
 
     async_add_entities(entities)
+
+    # Register entity service for SCENE buttons. Exposed as `grenton.run_scene`.
+    # The service only takes effect on entities that implement `run_with_parameter`
+    # (i.e. GrentonEntitySceneButton); regular buttons are unaffected.
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_RUN_SCENE,
+        SERVICE_RUN_SCENE_SCHEMA,
+        "run_with_parameter",
+    )

--- a/custom_components/homeassistant_grenton/domain/devices/scene.py
+++ b/custom_components/homeassistant_grenton/domain/devices/scene.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from .base import BaseGrentonDevice
+
+
+@dataclass
+class GrentonDeviceScene(BaseGrentonDevice):
+    """Device for SCENE widgets."""

--- a/custom_components/homeassistant_grenton/domain/entities/scene_button.py
+++ b/custom_components/homeassistant_grenton/domain/entities/scene_button.py
@@ -1,0 +1,39 @@
+from dataclasses import replace
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .base import BaseGrentonEntity
+from ..action import GrentonActionScript
+from ...coordinator import GrentonCoordinator
+
+
+class GrentonEntitySceneButton(BaseGrentonEntity, ButtonEntity): # pyright: ignore[reportIncompatibleVariableOverride]
+    """Button entity that runs a Grenton script and accepts a runtime parameter."""
+
+    def __init__(
+        self,
+        coordinator: GrentonCoordinator,
+        id: str,
+        label: str,
+        script_action: GrentonActionScript,
+        device_info: DeviceInfo | None = None,
+    ) -> None:
+        ButtonEntity.__init__(self)
+        BaseGrentonEntity.__init__(self, coordinator, id, label, device_info)
+        self.script_action = script_action
+
+    async def async_press(self, **kwargs: Any) -> None:
+        """Plain button press: run the script with the value baked into the widget."""
+        await self.coordinator.execute_action(self.script_action)
+
+    async def run_with_parameter(self, parameter: str | None = None) -> None:
+        """Run the script, overriding the widget's default value with ``parameter``.
+
+        ``parameter`` is passed verbatim into the script call payload, so the user
+        controls whether to pass a quoted Lua string (``"abc"``), a number (``42``),
+        or no argument at all (empty string -> ``script()``).
+        """
+        action = self.script_action if parameter is None else replace(self.script_action, value=parameter)
+        await self.coordinator.execute_action(action)

--- a/custom_components/homeassistant_grenton/dto/components/button_monostable.py
+++ b/custom_components/homeassistant_grenton/dto/components/button_monostable.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from typing import Literal, List
+
+from .base import GrentonComponentDto
+from ..action import GrentonActionUnionDto
+
+
+class GrentonComponentButtonMonostableDto(GrentonComponentDto):
+    type: Literal["BUTTON_MONOSTABLE"] = "BUTTON_MONOSTABLE"
+    actions: List[GrentonActionUnionDto]

--- a/custom_components/homeassistant_grenton/dto/widgets/scene.py
+++ b/custom_components/homeassistant_grenton/dto/widgets/scene.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from typing import Literal, List
+
+from .base import GrentonWidgetDto
+from ..components.button_monostable import GrentonComponentButtonMonostableDto
+
+
+class GrentonWidgetSceneDto(GrentonWidgetDto):
+    type: Literal["SCENE"] = "SCENE"
+    components: List[GrentonComponentButtonMonostableDto]

--- a/custom_components/homeassistant_grenton/dto/widgets/union.py
+++ b/custom_components/homeassistant_grenton/dto/widgets/union.py
@@ -15,6 +15,7 @@ from .multisensor import GrentonWidgetMultisensorDto
 from .roller_shutter import GrentonWidgetRollerShutterDto
 from .roller_shutter_v3 import GrentonWidgetRollerShutterV3Dto
 from .camera import GrentonWidgetCameraDto
+from .scene import GrentonWidgetSceneDto
 
 # Discriminated union using the 'type' field for secure deserialization
 GrentonWidgetUnionDto = Annotated[
@@ -32,6 +33,7 @@ GrentonWidgetUnionDto = Annotated[
         GrentonWidgetRollerShutterDto,
         GrentonWidgetRollerShutterV3Dto,
         GrentonWidgetCameraDto,
+        GrentonWidgetSceneDto,
     ],
     Field(discriminator="type"),
 ]

--- a/custom_components/homeassistant_grenton/mappers/device_mapper.py
+++ b/custom_components/homeassistant_grenton/mappers/device_mapper.py
@@ -16,6 +16,7 @@ from ..dto.widgets.multisensor import GrentonWidgetMultisensorDto
 from ..dto.widgets.roller_shutter import GrentonWidgetRollerShutterDto
 from ..dto.widgets.roller_shutter_v3 import GrentonWidgetRollerShutterV3Dto
 from ..dto.widgets.camera import GrentonWidgetCameraDto
+from ..dto.widgets.scene import GrentonWidgetSceneDto
 from ..dto.mobile_interface import GrentonMobileInterfaceDto
 
 from .device_value_v2 import DeviceValueV2Mapper
@@ -31,6 +32,7 @@ from .device_multisensor import DeviceMultisensorMapper
 from .device_roller_shutter import DeviceRollerShutterMapper
 from .device_roller_shutter_v3 import DeviceRollerShutterV3Mapper
 from .device_camera import DeviceCameraMapper
+from .device_scene import DeviceSceneMapper
 
 
 class DeviceMapper:
@@ -63,9 +65,11 @@ class DeviceMapper:
             return DeviceRollerShutterMapper.to_domain(dto, coordinator)
         if isinstance(dto, GrentonWidgetRollerShutterV3Dto): 
             return DeviceRollerShutterV3Mapper.to_domain(dto, coordinator)
-        if isinstance(dto, GrentonWidgetCameraDto): # type: ignore
+        if isinstance(dto, GrentonWidgetCameraDto):
             return DeviceCameraMapper.to_domain(dto, coordinator)
-        
+        if isinstance(dto, GrentonWidgetSceneDto): # type: ignore
+            return DeviceSceneMapper.to_domain(dto, coordinator)
+
         raise ValueError(f"Unknown widget type: {type(dto)}")
 
     @staticmethod

--- a/custom_components/homeassistant_grenton/mappers/device_scene.py
+++ b/custom_components/homeassistant_grenton/mappers/device_scene.py
@@ -1,0 +1,46 @@
+"""Mapper for converting Scene widget DTO to domain device."""
+
+from ..coordinator import GrentonCoordinator
+from ..domain.devices.scene import GrentonDeviceScene
+from ..domain.enums import GrentonActionEventType
+from ..domain.action import GrentonAction, GrentonActionScript
+from ..domain.entities.base import BaseGrentonEntity
+from ..domain.entities.scene_button import GrentonEntitySceneButton
+from ..dto.widgets.scene import GrentonWidgetSceneDto
+
+
+class DeviceSceneMapper:
+    """Mapper for GrentonWidgetSceneDto to GrentonDeviceScene."""
+
+    @staticmethod
+    def to_domain(dto: GrentonWidgetSceneDto, coordinator: GrentonCoordinator) -> GrentonDeviceScene:
+        device = GrentonDeviceScene(
+            type=dto.type,
+            id=dto.id,
+            entities=[],
+        )
+
+        entities: list[BaseGrentonEntity] = []
+        for component in dto.components:
+            # Find the CLICK action of type SCRIPT — the only one supported for SCENE today.
+            script_action: GrentonActionScript | None = None
+            for action_dto in component.actions or []:
+                action = GrentonAction.from_dto(action_dto)
+                if action.event == GrentonActionEventType.CLICK and isinstance(action, GrentonActionScript):
+                    script_action = action
+                    break
+
+            if script_action is None:
+                continue
+
+            entity = GrentonEntitySceneButton(
+                coordinator=coordinator,
+                id=f"{dto.id}_{component.rowId}",
+                label=component.label,
+                script_action=script_action,
+                device_info=device.device_info,
+            )
+            entities.append(entity)
+
+        device.entities = entities
+        return device

--- a/custom_components/homeassistant_grenton/services.yaml
+++ b/custom_components/homeassistant_grenton/services.yaml
@@ -1,0 +1,18 @@
+run_scene:
+  name: Run scene
+  description: Run a Grenton SCENE script, optionally passing a parameter.
+  target:
+    entity:
+      integration: grenton
+      domain: button
+  fields:
+    parameter:
+      name: Parameter
+      description: >
+        Optional parameter passed verbatim into the script call. Use Lua syntax
+        (e.g. quoted "abc" for a string, 42 for a number). Leave empty to run
+        with the default value defined in the scene widget.
+      example: "\"123\""
+      required: false
+      selector:
+        text:

--- a/custom_components/homeassistant_grenton/translations/en.json
+++ b/custom_components/homeassistant_grenton/translations/en.json
@@ -80,7 +80,23 @@
     }
   },
 
+  "services": {
+    "run_scene": {
+      "name": "Run scene",
+      "description": "Run a Grenton SCENE script, optionally passing a parameter.",
+      "fields": {
+        "parameter": {
+          "name": "Parameter",
+          "description": "Optional value passed verbatim into the script call (Lua syntax: \"abc\" for string, 42 for number). Leave empty to use the widget's default value."
+        }
+      }
+    }
+  },
+
   "device": {
+    "scene": {
+      "name": "Scene"
+    },
     "on_off": {
       "name": "On/Off Switch"
     },

--- a/custom_components/homeassistant_grenton/translations/pl.json
+++ b/custom_components/homeassistant_grenton/translations/pl.json
@@ -80,7 +80,23 @@
     }
   },
 
+  "services": {
+    "run_scene": {
+      "name": "Uruchom scenę",
+      "description": "Uruchamia skrypt sceny Grenton, opcjonalnie przekazując parametr.",
+      "fields": {
+        "parameter": {
+          "name": "Parametr",
+          "description": "Opcjonalna wartość przekazywana dosłownie do wywołania skryptu (składnia Lua: \"abc\" dla stringa, 42 dla liczby). Pozostaw puste, aby użyć domyślnej wartości z widgetu."
+        }
+      }
+    }
+  },
+
   "device": {
+    "scene": {
+      "name": "Scena"
+    },
     "on_off": {
       "name": "Przełącznik On/Off"
     },


### PR DESCRIPTION
Wires the SCENE widget type into the integration. Each SCENE component (BUTTON_MONOSTABLE) becomes a Button entity in Home Assistant that runs its bound Grenton script. Two ways to trigger it:

- button.press: runs the script with the value baked into the widget DTO
- grenton.run_scene: runs the script with a runtime parameter passed verbatim into the call payload, so the user can use Lua syntax for strings, numbers, or no argument at all

Parameter is raw passthrough — the OM editor already required users to quote string values themselves, so this preserves the same mental model.

Adds DTO (button_monostable component + scene widget), domain device, GrentonEntitySceneButton (dataclasses.replace to override action value without mutating the cached default), mapper, dispatcher, services.yaml, and EN/PL translation strings.